### PR TITLE
feat(module): add private NAT gateway module and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ module "nat_public_gateway" {
   ...
 }
 ```
+```hcl
+# Use the latest version.
+module "nat_private_gateway" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-nat/modules/nat-private-gateway"
+
+  ...
+}
+```
 
 ## Contributing
 

--- a/examples/nat-private-gateway/README.md
+++ b/examples/nat-private-gateway/README.md
@@ -1,0 +1,57 @@
+# Private NAT gateway
+
+Configuration in this directory creates a small type private NAT gateway.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| Terraform | >= 1.3.0 |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name | Source | Version |
+|------|--------|---------|
+| vpc_network | [terraform-huaweicloud-vpc](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc) | v1.2.0 |
+| nat_private_gateway | [../../modules/nat-private-gateway](../../modules/nat-private-gateway/README.md) | N/A |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name | Type |
+|------|------|
+| data.huaweicloud_availability_zones.this | data source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name | Description | Value |
+|------|-------------|-------|
+| region_name | The region where the resources are located | `"cn-north-4"` |
+| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | `"0"` |
+| vpc_name | The name of the VPC resource | `"VPC-Test"` |
+| vpc_cidr | The CIDR block of the VPC resource | `"192.168.0.0/24"` |
+| subnets_configuration | The configuration for the subnet resources to which the VPC belongs | <pre>[<br>  {<br>    "name": "VPC-Subnet-Test",<br>    "cidr": "192.168.0.0/24",<br>    "ipv6_enabled": false,<br>    "dhcp_enabled": false<br>  }<br>]</pre> |
+| private_gateway_name | The name of the private NAT gateway | `"NAT-Private-Gateway-Test"` |
+| private_gateway_specification | The specification of the public NAT gateway | `"Small"` |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| private_gateway_id | The ID of the private NAT gateway |

--- a/examples/nat-private-gateway/main.tf
+++ b/examples/nat-private-gateway/main.tf
@@ -1,0 +1,31 @@
+provider "huaweicloud" {
+  region = var.region_name
+}
+
+data "huaweicloud_availability_zones" "this" {}
+
+module "vpc_network" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc?ref=v1.2.0"
+
+  enterprise_project_id = var.enterprise_project_id
+
+  availability_zone = try(data.huaweicloud_availability_zones.this.names[0], "")
+
+  vpc_name              = var.vpc_name
+  vpc_cidr              = var.vpc_cidr
+  subnets_configuration = var.subnets_configuration
+
+  is_security_group_create = false
+}
+
+module "nat_private_gateway" {
+  source = "../../modules/nat-private-gateway"
+
+  enterprise_project_id = var.enterprise_project_id
+
+  private_gateway_subnet_id     = try(element(module.vpc_network.subnet_ids, 0), "")
+  private_gateway_name          = var.private_gateway_name
+  private_gateway_specification = var.private_gateway_specification
+
+  is_transit_ip_create = false
+}

--- a/examples/nat-private-gateway/outputs.tf
+++ b/examples/nat-private-gateway/outputs.tf
@@ -1,0 +1,5 @@
+output "private_gateway_id" {
+  description = "The ID of the private NAT gateway"
+
+  value = module.nat_private_gateway.private_gateway_id
+}

--- a/examples/nat-private-gateway/variables.json
+++ b/examples/nat-private-gateway/variables.json
@@ -1,0 +1,16 @@
+{
+  "region_name": "cn-north-4",
+  "enterprise_project_id": "0",
+  "vpc_name": "VPC-Test",
+  "vpc_cidr": "192.168.0.0/24",
+  "subnets_configuration": [
+    {
+      "name": "VPC-Subnet-Test",
+      "cidr": "192.168.0.0/24",
+      "ipv6_enabled": false,
+      "dhcp_enabled": false
+    }
+  ],
+  "private_gateway_name": "NAT-Private-Gateway-Test",
+  "private_gateway_specification": "Small"
+}

--- a/examples/nat-private-gateway/variables.tf
+++ b/examples/nat-private-gateway/variables.tf
@@ -1,0 +1,62 @@
+######################################################################
+# Public configurations
+######################################################################
+
+variable "region_name" {
+  description = "The region where the resources are located"
+
+  type = string
+}
+
+variable "enterprise_project_id" {
+  description = "Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users)"
+
+  type = string
+}
+
+######################################################################
+# Configurations of VPC resource and related resources
+######################################################################
+
+variable "vpc_name" {
+  description = "The name of the VPC resource"
+
+  type = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC resource"
+
+  type = string
+}
+
+variable "subnets_configuration" {
+  description = "The configuration for the subnet resources to which the VPC belongs"
+
+  type = list(object({
+    name           = string
+    description    = optional(string, null)
+    cidr           = string
+    ipv6_enabled   = optional(bool, true)
+    dhcp_enabled   = optional(bool, true)
+    dns_list       = optional(list(string), null)
+    tags           = optional(map(string), {})
+    delete_timeout = optional(string, null)
+  }))
+}
+
+######################################################################
+# Configurations of private NAT gateway resource
+######################################################################
+
+variable "private_gateway_name" {
+  description = "The name of the private NAT gateway"
+
+  type = string
+}
+
+variable "private_gateway_specification" {
+  description = "The specification of the private NAT gateway"
+
+  type = string
+}

--- a/examples/nat-private-gateway/versions.tf
+++ b/examples/nat-private-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/examples/nat-private-transit-ip/README.md
+++ b/examples/nat-private-transit-ip/README.md
@@ -1,0 +1,55 @@
+# Transit IP
+
+Configuration in this directory creates a transit IP.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan -var-file=variables.json
+$ terraform apply -var-file=variables.json
+```
+
+Run `terraform destroy -var-file=variables.json` when you don't need these resources.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| Terraform | >= 1.3.0 |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+<!-- markdownlint-disable MD013 -->
+| Name | Source | Version |
+|------|--------|---------|
+| vpc_network | [terraform-huaweicloud-vpc](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc) | v1.2.0 |
+| nat_private_transit_ip | [../../modules/nat-private-gateway](../../modules/nat-private-gateway/README.md) | N/A |
+<!-- markdownlint-enable MD013 -->
+
+## Resources
+
+| Name | Type |
+|------|------|
+| data.huaweicloud_availability_zones.this | data source |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name | Description | Value |
+|------|-------------|-------|
+| region_name | The region where the resources are located | `"cn-north-4"` |
+| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | `"0"` |
+| vpc_name | The name of the VPC resource | `"VPC-Test"` |
+| vpc_cidr | The CIDR block of the VPC resource | `"172.16.0.0/24"` |
+| subnets_configuration | The configuration for the subnet resources to which the VPC belongs | <pre>[<br>  {<br>    "name": "VPC-Subnet-Test",<br>    "cidr": "172.16.0.0/24",<br>    "ipv6_enabled": false,<br>    "dhcp_enabled": false<br>  }<br>]</pre> |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| transit_ip_id | The ID of the transit IP |

--- a/examples/nat-private-transit-ip/main.tf
+++ b/examples/nat-private-transit-ip/main.tf
@@ -1,0 +1,30 @@
+provider "huaweicloud" {
+  region = var.region_name
+}
+
+data "huaweicloud_availability_zones" "this" {}
+
+module "vpc_network" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-vpc?ref=v1.2.0"
+
+  enterprise_project_id = var.enterprise_project_id
+
+  availability_zone = try(data.huaweicloud_availability_zones.this.names[0], "")
+
+  vpc_name              = var.vpc_name
+  vpc_cidr              = var.vpc_cidr
+  subnets_configuration = var.subnets_configuration
+
+  is_security_group_create = false
+}
+
+module "nat_private_transit_ip" {
+  source = "../../modules/nat-private-gateway"
+
+  enterprise_project_id = var.enterprise_project_id
+
+  transit_ip_subnet_id = try(element(module.vpc_network.subnet_ids, 0), "")
+
+
+  is_private_gateway_create = false
+}

--- a/examples/nat-private-transit-ip/outputs.tf
+++ b/examples/nat-private-transit-ip/outputs.tf
@@ -1,0 +1,5 @@
+output "transit_ip_id" {
+  description = "The ID of the transit IP"
+
+  value = module.nat_private_transit_ip.transit_ip_id
+}

--- a/examples/nat-private-transit-ip/variables.json
+++ b/examples/nat-private-transit-ip/variables.json
@@ -1,0 +1,14 @@
+{
+  "region_name": "cn-north-4",
+  "enterprise_project_id": "0",
+  "vpc_name": "VPC-Test",
+  "vpc_cidr": "172.16.0.0/24",
+  "subnets_configuration": [
+    {
+      "name": "VPC-Subnet-Test",
+      "cidr": "172.16.0.0/24",
+      "ipv6_enabled": false,
+      "dhcp_enabled": false
+    }
+  ]
+}

--- a/examples/nat-private-transit-ip/variables.tf
+++ b/examples/nat-private-transit-ip/variables.tf
@@ -1,0 +1,46 @@
+######################################################################
+# Public configurations
+######################################################################
+
+variable "region_name" {
+  description = "The region where the resources are located"
+
+  type = string
+}
+
+variable "enterprise_project_id" {
+  description = "Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users)"
+
+  type = string
+}
+
+######################################################################
+# Configurations of VPC resource and related resources
+######################################################################
+
+variable "vpc_name" {
+  description = "The name of the VPC resource"
+
+  type = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block of the VPC resource"
+
+  type = string
+}
+
+variable "subnets_configuration" {
+  description = "The configuration for the subnet resources to which the VPC belongs"
+
+  type = list(object({
+    name           = string
+    description    = optional(string, null)
+    cidr           = string
+    ipv6_enabled   = optional(bool, true)
+    dhcp_enabled   = optional(bool, true)
+    dns_list       = optional(list(string), null)
+    tags           = optional(map(string), {})
+    delete_timeout = optional(string, null)
+  }))
+}

--- a/examples/nat-private-transit-ip/versions.tf
+++ b/examples/nat-private-transit-ip/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}

--- a/modules/nat-private-gateway/README.md
+++ b/modules/nat-private-gateway/README.md
@@ -1,0 +1,104 @@
+# Private NAT Gateway management
+
+Manages the private NAT gateway resource.
+
+## Notes
+
+### How to import resources in the module structure
+
+If you want to manage an existing private NAT gateway using Terraform (otherwise why are you reading this?) you need to
+make sure that the corresponding module script has been defined in your `.tf` file, like this:
+
+```hcl
+# Manages a private NAT gateway.
+module "nat_private_gateway" {
+  source = "github.com/terraform-huaweicloud-modules/terraform-huaweicloud-nat/modules/nat-private-gateway"
+
+  ...
+}
+```
+
+Then, execute the following command to import the corresponding resource into the management of the `.tfstate` file.
+
+```bash
+$ terraform import module.nat_private_gateway.huaweicloud_nat_private_gateway.this[0] "private_gateway_id"
+
+module.nat_private_gateway.huaweicloud_nat_private_gateway.this[0]: Importing from ID "private_gateway_id"...
+module.nat_private_gateway.huaweicloud_nat_private_gateway.this[0]: Import complete!
+  Imported huaweicloud_nat_private_gateway (ID: private_gateway_id)
+module.nat_private_gateway.huaweicloud_nat_private_gateway.this[0]: Refreshing state... (ID: private_gateway_id)
+
+Import successful!
+
+The resources that were imported are shown above. These resources are now in
+your Terraform state and will henceforth be managed by Terraform.
+```
+
+### What should we do before deploy this module example
+
+Before manage NAT resources, the access key (AK, the corresponding environment name is `HW_ACCESS_KEY`) and the secret key (SK, the corresponding environment name is `HW_SECRET_KEY`) should be configured.
+
+For the linux VM, you can configure the corresponding environment variables with the following commands:
+
+```bash
+$ export HW_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXX
+$ export HW_SECRET_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+Refer to this [document](https://support.huaweicloud.com/intl/en-us/devg-apisign/api-sign-provide-aksk.html) for AK/SK information obtain.
+
+## Contributing
+
+Report issues/questions/feature requests in the [issues](https://github.com/terraform-huaweicloud-modules/terraform-huaweicloud-nat/issues/new)
+section.
+
+Full contributing [guidelines are covered here](../../github/how_to_contribute.md).
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| Terraform | >= 1.3.0 |
+| Huaweicloud Provider | >= 1.73.0 |
+
+## Modules
+
+No module.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| huaweicloud_nat_private_gateway.this | resource |
+| huaweicloud_nat_private_transit_ip.this | resource |
+| huaweicloud_nat_private_snat_rule.this | resource |
+| huaweicloud_nat_private_dnat_rule.this | resource |
+
+## Inputs
+
+<!-- markdownlint-disable MD013 -->
+| Name | Description | Type | Default | Required |
+|------|-------------|------|:-------:|:--------:|
+| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | `string` | `""` | N |
+| is_private_gateway_create | Controls whether a private NAT gateway should be created | `bool` | `true` | N |
+| private_gateway_subnet_id | The network ID of the subnet to which the private NAT gateway belongs | `string` | `""` | Y (Unless is_private_gateway_create is specified as false) |
+| private_gateway_name | The name of the private NAT gateway | `string` | `""` | Y (Unless is_private_gateway_create is specified as false) |
+| private_gateway_specification | The specification of the private NAT gateway | `string` | `""` | Y (Unless is_private_gateway_create is specified as false) |
+| private_gateway_description | The description of the private NAT gateway | `string` | `""` | N |
+| private_gateway_tags | The key/value pairs to associate with the private NAT gateway | <pre>map(string)</pre> | <pre>{}</pre> | N |
+| is_transit_ip_create | Controls whether a transit IP should be created | `bool` | `true` | N |
+| transit_ip_subnet_id | The transit subnet ID to which the transit IP belongs | `string` | `""` | Y (Unless is_transit_ip_create is specified as false) |
+| transit_ip_ip_address | The IP address of the transit subnet | `string` | `""` | N |
+| transit_ip_tags | The key/value pairs to associate with the transit IP | <pre>map(string)</pre> | <pre>{}</pre> | N |
+| private_dnat_rules_configuration | The configuration for the private DNAT rule resources associate with the private NAT gateway | <pre>list(object({<br>  gateway_id            = optional(string, "")<br>  transit_ip_id         = optional(string, "")<br>  transit_service_port  = optional(number, null)<br>  protocol              = optional(string, "")<br>  backend_interface_id  = optional(string, "")<br>  backend_private_ip    = optional(string, "")<br>  internal_service_port = optional(number, null)<br>  description           = optional(string, "")<br>}))</pre> | <pre>[]</pre> | N |
+| private_snat_rules_configuration | The configuration for the private SNAT rule resources associate with the private NAT gateway | <pre>list(object({<br>  gateway_id    = optional(string, "")<br>  transit_ip_id = optional(string, "")<br>  cidr          = optional(string, "")<br>  subnet_id     = optional(string, "")<br>  description   = optional(string, "")<br>}))</pre> | <pre>[]</pre> | N |
+<!-- markdownlint-enable MD013 -->
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| private_gateway_id | The ID of the private NAT gateway |
+| transit_ip_id | The ID of the transit IP |
+| private_dnat_rules_configuration | The basic configuration list of the private DNAT rules |
+| private_snat_rules_configuration | The basic configuration list of the private SNAT rules |

--- a/modules/nat-private-gateway/main.tf
+++ b/modules/nat-private-gateway/main.tf
@@ -1,0 +1,77 @@
+resource "huaweicloud_nat_private_gateway" "this" {
+  count = var.is_private_gateway_create ? 1 : 0
+
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  subnet_id   = var.private_gateway_subnet_id
+  name        = var.private_gateway_name
+  spec        = var.private_gateway_specification
+  description = var.private_gateway_description != "" ? var.private_gateway_description : null
+  tags        = var.private_gateway_tags
+
+  lifecycle {
+    precondition {
+      condition     = var.private_gateway_subnet_id != ""
+      error_message = "The private_gateway_subnet_id is required if the is_private_gateway_create is true."
+    }
+    precondition {
+      condition     = var.private_gateway_name != ""
+      error_message = "The private_gateway_name is required if the is_private_gateway_create is true."
+    }
+    precondition {
+      condition     = var.private_gateway_specification != ""
+      error_message = "The private_gateway_specification is required if the is_private_gateway_create is true."
+    }
+  }
+}
+
+resource "huaweicloud_nat_private_transit_ip" "this" {
+  count = var.is_transit_ip_create ? 1 : 0
+
+  enterprise_project_id = var.enterprise_project_id != "" ? var.enterprise_project_id : null
+
+  subnet_id  = var.transit_ip_subnet_id
+  ip_address = var.transit_ip_ip_address != "" ? var.transit_ip_ip_address : null
+  tags       = var.transit_ip_tags
+
+  lifecycle {
+    precondition {
+      condition     = var.transit_ip_subnet_id != ""
+      error_message = "The transit_ip_subnet_id is required if the is_transit_ip_create is true."
+    }
+  }
+}
+
+resource "huaweicloud_nat_private_dnat_rule" "this" {
+  count = length(var.private_dnat_rules_configuration)
+
+  gateway_id            = lookup(element(var.private_dnat_rules_configuration, count.index), "gateway_id", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "gateway_id") : var.is_private_gateway_create ? huaweicloud_nat_private_gateway.this[0].id : ""
+  transit_ip_id         = lookup(element(var.private_dnat_rules_configuration, count.index), "transit_ip_id", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "transit_ip_id") : var.is_transit_ip_create ? huaweicloud_nat_private_transit_ip.this[0].id : ""
+  transit_service_port  = lookup(element(var.private_dnat_rules_configuration, count.index), "transit_service_port", null)
+  protocol              = lookup(element(var.private_dnat_rules_configuration, count.index), "protocol", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "protocol") : null
+  backend_interface_id  = lookup(element(var.private_dnat_rules_configuration, count.index), "backend_interface_id", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "backend_interface_id") : null
+  backend_private_ip    = lookup(element(var.private_dnat_rules_configuration, count.index), "backend_private_ip", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "backend_private_ip") : null
+  internal_service_port = lookup(element(var.private_dnat_rules_configuration, count.index), "internal_service_port", null)
+  description           = lookup(element(var.private_dnat_rules_configuration, count.index), "description", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "description") : null
+}
+
+resource "huaweicloud_nat_private_snat_rule" "this" {
+  count = length(var.private_snat_rules_configuration)
+
+  gateway_id    = lookup(element(var.private_snat_rules_configuration, count.index), "gateway_id", "") != "" ? lookup(element(var.private_snat_rules_configuration,
+    count.index), "gateway_id") : var.is_private_gateway_create ? huaweicloud_nat_private_gateway.this[0].id : ""
+  transit_ip_id = lookup(element(var.private_snat_rules_configuration, count.index), "transit_ip_id", "") != "" ? lookup(element(var.private_dnat_rules_configuration,
+    count.index), "transit_ip_id") : var.is_transit_ip_create ? huaweicloud_nat_private_transit_ip.this[0].id : ""
+  cidr          = lookup(element(var.private_snat_rules_configuration, count.index), "cidr", "") != "" ? lookup(element(var.private_snat_rules_configuration,
+    count.index), "cidr") : null
+  subnet_id     = lookup(element(var.private_snat_rules_configuration, count.index), "subnet_id", "") != "" ? lookup(element(var.private_snat_rules_configuration,
+    count.index), "subnet_id") : null
+  description   = lookup(element(var.private_snat_rules_configuration, count.index), "description", "") != "" ? lookup(element(var.private_snat_rules_configuration,
+    count.index), "description") : null
+}

--- a/modules/nat-private-gateway/outputs.tf
+++ b/modules/nat-private-gateway/outputs.tf
@@ -1,0 +1,31 @@
+output "private_gateway_id" {
+  description = "The ID of the private NAT gateway"
+
+  value = try(huaweicloud_nat_private_gateway.this[0].id, "")
+}
+
+output "transit_ip_id" {
+  description = "The ID of the transit IP"
+
+  value = try(huaweicloud_nat_private_transit_ip.this[0].id, "")
+}
+
+output "private_dnat_rules_configuration" {
+  description = "The basic configuration list of the private DNAT rules"
+
+  value = try([for o in huaweicloud_nat_private_dnat_rule.this : {
+    "id" : o.id,
+    "backend_private_ip" : o.backend_private_ip,
+    "backend_type" : o.backend_type,
+  }], [])
+}
+
+output "private_snat_rules_configuration" {
+  description = "The basic configuration list of the private SNAT rules"
+
+  value = try([for o in huaweicloud_nat_private_snat_rule.this : {
+    "id" : o.id,
+    "cidr": o.cidr,
+    "transit_ip_address" : o.transit_ip_address,
+  }], [])
+}

--- a/modules/nat-private-gateway/variables.tf
+++ b/modules/nat-private-gateway/variables.tf
@@ -1,0 +1,129 @@
+######################################################################
+# Public configurations
+######################################################################
+
+variable "enterprise_project_id" {
+  description = "Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users)"
+
+  type    = string
+  default = ""
+}
+
+######################################################################
+# Configurations of NAT private gateway resource
+######################################################################
+
+variable "is_private_gateway_create" {
+  description = "Controls whether a private NAT gateway should be created"
+
+  type     = bool
+  default  = true
+  nullable = false
+}
+
+variable "private_gateway_subnet_id" {
+  description = "The network ID of the subnet to which the private NAT gateway belongs"
+
+  type    = string
+  default = ""
+}
+
+variable "private_gateway_name" {
+  description = "The name of the private NAT gateway"
+
+  type    = string
+  default = ""
+}
+
+variable "private_gateway_specification" {
+  description = "The specification of the private NAT gateway"
+
+  type    = string
+  default = ""
+}
+
+variable "private_gateway_description" {
+  description = "The description of the private NAT gateway"
+
+  type    = string
+  default = ""
+}
+
+variable "private_gateway_tags" {
+  description = "The key/value pairs to associate with the private NAT gateway"
+
+  type    = map(string)
+  default = {}
+}
+
+######################################################################
+# Configurations of NAT transit IP resource
+######################################################################
+
+variable "is_transit_ip_create" {
+  description = "Controls whether a transit IP should be created"
+
+  type     = bool
+  default  = true
+  nullable = false
+}
+
+variable "transit_ip_subnet_id" {
+  description = "The transit subnet ID to which the transit IP belongs"
+
+  type    = string
+  default = ""
+}
+
+variable "transit_ip_ip_address" {
+  description = "The IP address of the transit subnet"
+
+  type    = string
+  default = ""
+}
+
+variable "transit_ip_tags" {
+  description = "The key/value pairs to associate with the transit IP"
+
+  type    = map(string)
+  default = {}
+}
+
+######################################################################
+# Configurations of NAT private DNAT rule resources
+######################################################################
+
+variable "private_dnat_rules_configuration" {
+  description = "The configuration for the private DNAT rule resources associate with the private NAT gateway"
+
+  type = list(object({
+    gateway_id            = optional(string, "")
+    transit_ip_id         = optional(string, "")
+    transit_service_port  = optional(number, null)
+    protocol              = optional(string, "")
+    backend_interface_id  = optional(string, "")
+    backend_private_ip    = optional(string, "")
+    internal_service_port = optional(number, null)
+    description           = optional(string, "")
+  }))
+  default  = []
+  nullable = false
+}
+
+######################################################################
+# Configurations of NAT private SNAT rule resources
+######################################################################
+
+variable "private_snat_rules_configuration" {
+  description = "The configuration for the private SNAT rule resources associate with the private NAT gateway"
+
+  type = list(object({
+    gateway_id    = optional(string, "")
+    transit_ip_id = optional(string, "")
+    cidr          = optional(string, "")
+    subnet_id     = optional(string, "")
+    description   = optional(string, "")
+  }))
+  default  = []
+  nullable = false
+}

--- a/modules/nat-private-gateway/versions.tf
+++ b/modules/nat-private-gateway/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">= 1.73.0"
+    }
+  }
+}


### PR DESCRIPTION
Add private NAT gateway module and examples.

## test running module
![image](https://github.com/user-attachments/assets/24ba1de6-bef5-4895-b7d0-a30865984351)
## destroy running module
![image](https://github.com/user-attachments/assets/50e8ac0d-06c0-4bdb-8612-1e34fcb5b363)

## test running private NAT gateway example
![image](https://github.com/user-attachments/assets/ef3591c6-e5db-4559-8d87-c341e0190a31)
## destroy running private NAT gateway example
![image](https://github.com/user-attachments/assets/ead7fa1c-d40c-4fd7-b54a-7b01828ea086)

## test running private transit IP example
![image](https://github.com/user-attachments/assets/dc29d800-1316-4a62-b733-82e2be573fae)
## destroy running private transit IP example
![image](https://github.com/user-attachments/assets/a30c3fa5-db39-4557-b5cd-425378a4b739)
